### PR TITLE
ci: get PR SHA and number from the build data

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -35,6 +35,11 @@ jobs:
       run: mix compile --force --warnings-as-errors
     - name: Run tests
       run: mix test --cover
+    - name: Save PR information
+      run: |
+        echo "${{ github.event.pull_request.number }}" > coverage/PR_NUMBER
+        echo "${{ github.event.pull_request.head.sha }}" > coverage/PR_SHA
+      if: github.event.pull_request
     - name: Upload coverage artifact
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/report_coverage.yml
+++ b/.github/workflows/report_coverage.yml
@@ -15,10 +15,7 @@ jobs:
     steps:
     - run: echo Fetching artifacts for ${{ github.event.workflow_run.id }}, event name ${{ github.event_name }}, triggered by ${{ github.event.workflow_run.event }}
     - run: echo Should have run? ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
-
-    - uses: actions/checkout@v2 # UNTRUSTED CODE - do not run scripts from it
-      with:
-        ref: ${{ github.event.pull_request.head.sha }}
+    - run: mkdir -p ${{ env.RUNNER_TEMP }}/coverage
     - name: Download artifact
       uses: actions/github-script@v3.1.0
       with:
@@ -38,12 +35,19 @@ jobs:
             archive_format: 'zip',
           });
           var fs = require('fs');
-          fs.writeFileSync('${{github.workspace}}/elixir-lcov.zip', Buffer.from(download.data));
-    - run: unzip elixir-lcov.zip
+          fs.writeFileSync('${{env.RUNNER_TEMP}}/coverage/elixir-lcov.zip', Buffer.from(download.data));
+    - run: |
+        cd ${{env.RUNNER_TEMP}}/coverage
+        unzip elixir-lcov.zip
+        echo "::set-output name=PR_SHA::$(cat PR_SHA)"
+        echo "::set-output name=PR_NUMBER::$(cat PR_NUMBER)"
+    - uses: actions/checkout@v2 # UNTRUSTED CODE - do not run scripts from it
+      with:
+        ref: ${{ env.PR_SHA }}
     - run: ls
     - name: Upload coverage artifact and post comment
       uses: mbta/github-actions-report-lcov@v1
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        coverage-files: ./lcov*.info
+        coverage-files: ${{env.RUNNER_TEMP}}/coverage/lcov*.info
         artifact-name: elixir-code-coverage


### PR DESCRIPTION
It isn't reported for cross-repo pull requests.